### PR TITLE
chore: fix text overflowing and ruining chat

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -222,6 +222,9 @@ transition: 0.2s;
     text-align: left;
     padding-left: 10px;
     display: flex;
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;  
   }
 
 


### PR DESCRIPTION
When text is tooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooo long horizontally it overflows the message container making the chat scrollable not only on vertical
axis but also horizontal axis... that's... jank.

So i fixed it.

Before PR:
<img width="816" height="562" alt="image" src="https://github.com/user-attachments/assets/7f8ec385-a295-49da-ab0a-142e60b79644" />

After PR:
<img width="750" height="558" alt="image" src="https://github.com/user-attachments/assets/f97d250d-ffbc-432e-9476-dd3985434376" />
