### PR TITLE
Order channels alphabetically for now

### DIFF
--- a/src/components/channelList.vue
+++ b/src/components/channelList.vue
@@ -6,7 +6,7 @@
 
     <template v-if="done && currentServer?.storedChannels?.length">
       <button
-        v-for="(div, index) in currentServer.storedChannels"
+        v-for="(div, index) in currentServer.storedChannels.sort(compareChannels)"
         :key="index"
         @click="$emit('changeChannel', div.channelTag)"
         class="channel_button"
@@ -40,6 +40,15 @@ export default {
       const sv = this.userServers.find(obj => obj.serverID === this.serverID);
       return sv ? sv.name : "Unknown Server";
     },
+  },
+  methods: {
+	compareChannels(a, b){
+	  if(a.channelTag > b.channelTag)
+	    return 1;
+	  if(b.channelTag > a.channelTag)
+	    return -1;
+	  return 0;
+	}
   },
 };
 </script>


### PR DESCRIPTION
It would be nice to have a persistent customizable channel order, for now the channels will be sorted alphabetically so they're not randomized on each app load. The compare function can be modified quite easily to sort by an index given by the server, if/when the backend functionality is implemented