### PR TITLE
Add shai-hulud 2.0 check workflow for security

### DIFF
--- a/.github/workflows/shai-hulud-check.yml
+++ b/.github/workflows/shai-hulud-check.yml
@@ -2,9 +2,9 @@ name: Shai-Hulud 2.0 Security Check
 
 on:
   push:
-    branches: [main, master]
+    branches: main
   pull_request:
-    branches: [main, master]
+    branches: main
 
 jobs:
   security-check:


### PR DESCRIPTION
Since the SHA1-HULUD 2.0 malware is currently circulating around npm-based projects, we should make sure we avoid it. The current version of the project does not appear to use compromised packages, but it's best to be proactive and avoid getting infected if we add a new package or current ones get updated.