### PR TITLE
Fix issues related to logging in and logging out

### DIFF
--- a/src/AppWrapper.vue
+++ b/src/AppWrapper.vue
@@ -1,0 +1,21 @@
+<template>
+  <App :key="appKey"/>
+</template>
+
+<script>
+import { ref } from 'vue'
+import App from './App.vue'
+
+const appKey = ref(0)
+
+export function reloadApp() {
+  appKey.value++
+}
+
+export default {
+  components: { App },
+  setup() {
+    return { appKey }
+  }
+}
+</script>

--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-
+import { reloadApp } from './AppWrapper.vue'
 const HEARTBEAT_INTERVAL = 25000;
 
 export default {
@@ -319,7 +319,7 @@ export default {
           this.loggedin = true;
 
           invoke('write_credentials', { creds: JSON.stringify({ 'username': this.username, 'token': this.token }) });
-          this.getUserServers();
+          reloadApp();
         })
         .catch((err) => console.log(err));
     },

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
 import { createApp } from "vue";
-import App from "./App.vue";
+import AppWrapper from './AppWrapper.vue'
 
-createApp(App).mount("#app");
+createApp(AppWrapper).mount("#app");


### PR DESCRIPTION
This PR involves adding a component refresh that is called after logging in (instead of simply reloading the servers), fixing the following issues:
* Messages in servers not being visible if you start the application logged out and login after
* Channels and servers being duplicated if you log out and log back in without closing the app
Bring the component back to a clean slate on login should prevent similar issues from appearing in the future.