### PR TITLE
Websocket refactoring and improvements

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,5 +1,5 @@
 import { invoke } from '@tauri-apps/api/core';
-import { wsConnection } from './websocket.jsx';
+import { wsConnection } from './websocket.js';
 import { reloadApp } from './AppWrapper.vue'
 
 export default {

--- a/src/websocket.js
+++ b/src/websocket.js
@@ -25,7 +25,9 @@ export class wsConnection extends EventTarget{
     });
     this.message_ws.addEventListener("close", () => {
       console.log('[WEBSOCKET CONNECTION LOST. ATTEMPTING TO RECONNECT]');
-      clearInterval(this.heartbeat);
+      if(this.heartbeat != null) {
+        clearInterval(this.heartbeat);
+      }
       setTimeout(() => { this.connectWebsocket(); }, RECONNECT_INTERVAL);
     });
   }


### PR DESCRIPTION
In this PR, the following changes were made to the websocket implementation:
~~* Extracted the WS initialization procedure from the data() function to its own method `initWebsocket` which is called from the data function instead.~~
* The spellcaster connection is now fully managed by the `wsConnection` class.
  * `wsConnection` emits events when requiring the main application to complete a token exchange/handshake with od-spell-caster (when first opening the app, or when connection is temporarily lost)
  * `wsConnection` will forward all message-received events to the main app for decoding.
  * Once fully initialized, `wsConnection` is fully autonomous as long as handshake requests are properly handled. The main app binds to `wsConnection` once and doesn't need to keep track of web sockets opening or closing when connection is lost and restored.
* When the websocket is closed, it will attempt to reinitialize itself every 5 seconds until re-establishing connection.
* Messages received from spellcaster are now timestamped correctly.

Minor: Minutes are now padded properly (ex. 18:6 -> 18:06)

Because this is a relatively complicated architecture (compared to the rest of the frontend) I'll include the following diagram to help understand the sequence 
of events:
<img width="713" height="753" alt="ws drawio" src="https://github.com/user-attachments/assets/3418b7b9-3597-40ef-817e-ce3d7e67807e" />