### PR TITLE
Remove /api from links to coincide with latest server version.

### DIFF
--- a/src-tauri/src/api/channels.rs
+++ b/src-tauri/src/api/channels.rs
@@ -9,7 +9,7 @@ pub(crate) async fn getchannels(host_url: String, token: String, server: String,
     map.insert("token", token.clone());
     map.insert("username", username.clone());
     prelude::debug_only_print(&token);
-    let res = post_to_text(&format!("{}/{}/api/get_channels", host_url, server), map, "Failed to get channels.")
+    let res = post_to_text(&format!("{}/{}/get_channels", host_url, server), map, "Failed to get channels.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -28,7 +28,7 @@ pub(crate) async fn create_channel(
     map.insert("username", username.clone());
     map.insert("channel_name", channel_name.clone());
     map.insert("token", token.clone());
-    let res = post_to_text(&format!("{}/{}/api/create_channel",host_url,server_id.clone()), map, "Failed to create channel.")
+    let res = post_to_text(&format!("{}/{}/create_channel",host_url,server_id.clone()), map, "Failed to create channel.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -46,7 +46,7 @@ pub(crate) async fn delete_channel(
 	let mut map = std::collections::HashMap::new();
 	map.insert("username", username.clone());
     map.insert("token", token.clone());
-    let res = post_to_text(&format!("{}/{}/api/{}/delete_channel",host_url,server_id.clone(),channel_name.clone()), map, "Failed to delete channel.")
+    let res = post_to_text(&format!("{}/{}/{}/delete_channel",host_url,server_id.clone(),channel_name.clone()), map, "Failed to delete channel.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);

--- a/src-tauri/src/api/messages.rs
+++ b/src-tauri/src/api/messages.rs
@@ -17,7 +17,7 @@ pub(crate) async fn sendmessage(
     map.insert("m_content", m_content.clone());
     map.insert("username", username.clone());
     prelude::debug_only_print(&m_content.clone());
-    let res = post(&format!("{}/{}/api/{}/send_message",host_url, server, channel), map).await;
+    let res = post(&format!("{}/{}/{}/send_message",host_url, server, channel), map).await;
     prelude::debug_only_print(&res);
     match res {
         Ok(_) => m_content,
@@ -38,7 +38,7 @@ pub(crate) async fn getmessages(
     map.insert("username", username.clone());
     map.insert("limit", "100".to_string());
     map.insert("offset", "0".to_string());
-    let res = post_to_text(&format!("{}/{}/api/{}/get_messages_migration",host_url, server, channel), map, "Failed to retrieve messages")
+    let res = post_to_text(&format!("{}/{}/{}/get_messages_migration",host_url, server, channel), map, "Failed to retrieve messages")
         .await
         .expect("err");
     prelude::debug_only_print(&res);

--- a/src-tauri/src/api/servers.rs
+++ b/src-tauri/src/api/servers.rs
@@ -9,7 +9,7 @@ pub(crate) async fn getservers(token: String, username: String) -> String {
     map.insert("token", token.clone());
     map.insert("username", username.clone());
     prelude::debug_only_print(&format!("getservers {}", token));
-    let res = post_to_text("https://api.onlinedi.vision/api/get_user_servers", map, "Failed to get use servers.")
+    let res = post_to_text("https://api.onlinedi.vision/get_user_servers", map, "Failed to get use servers.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -18,7 +18,7 @@ pub(crate) async fn getservers(token: String, username: String) -> String {
 
 #[tauri::command(rename_all = "snake_case")]
 pub(crate) async fn get_server_info(server_id: String) -> String {
-    let res = get_to_text(&format!("https://api.onlinedi.vision/servers/{}/api/get_server_info",server_id), "Failed to get server info.")
+    let res = get_to_text(&format!("https://api.onlinedi.vision/servers/{}/get_server_info",server_id), "Failed to get server info.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -40,7 +40,7 @@ pub(crate) async fn create_server(
     map.insert("img_url", img_url.clone());
     map.insert("token", token.clone());
     prelude::debug_only_print(&map);
-    let res = post_to_text("https://api.onlinedi.vision/api/create_server", map, "Failed to create server.")
+    let res = post_to_text("https://api.onlinedi.vision/create_server", map, "Failed to create server.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -58,7 +58,7 @@ pub(crate) async fn join_server(
     map.insert("username", username.clone());
     map.insert("token", token.clone());
     prelude::debug_only_print(&map);
-    let res = post_to_text(&format!("{}/{}/api/join", host_url, server_id.clone()), map, "Failed to join server.")
+    let res = post_to_text(&format!("{}/{}/join", host_url, server_id.clone()), map, "Failed to join server.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -75,7 +75,7 @@ pub(crate) async fn get_server_users(
     let mut map = std::collections::HashMap::new();
     map.insert("token", token.clone());
     map.insert("username", username.clone());
-    let res = post_to_text(&format!("{}/{}/api/get_server_users",host_url, server), map, "Failed to get server users.")
+    let res = post_to_text(&format!("{}/{}/get_server_users",host_url, server), map, "Failed to get server users.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);

--- a/src-tauri/src/api/spell_caster.rs
+++ b/src-tauri/src/api/spell_caster.rs
@@ -14,7 +14,7 @@ pub(crate) async fn spellcheck(
     map.insert("username", username.clone());
     map.insert("key", key.clone());
 
-    let res = post_to_text("https://api.onlinedi.vision/api/spell/check", map, "Spell Check Failed").await
+    let res = post_to_text("https://api.onlinedi.vision/spell/check", map, "Spell Check Failed").await
         .expect("err");
     prelude::debug_only_print(&res);
     res

--- a/src-tauri/src/api/users.rs
+++ b/src-tauri/src/api/users.rs
@@ -9,7 +9,7 @@ pub(crate) async fn login(password: String, username: String) -> String {
     map.insert("password", password.clone());
     map.insert("username", username.clone());
     prelude::debug_only_print(&username);
-    let res = post_to_text("https://api.onlinedi.vision/api/try_login", map, "Failed to Log in.")
+    let res = post_to_text("https://api.onlinedi.vision/try_login", map, "Failed to Log in.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -23,7 +23,7 @@ pub(crate) async fn signup(password: String, username: String, email: String) ->
     map.insert("username", username.clone());
     map.insert("email", email.clone());
     prelude::debug_only_print(&username);
-    let res = post_to_text("https://api.onlinedi.vision/api/new_user", map, "Failed to create new user.")
+    let res = post_to_text("https://api.onlinedi.vision/new_user", map, "Failed to create new user.")
         .await
         .expect("err");
     prelude::debug_only_print(&res);
@@ -38,7 +38,7 @@ pub(crate) async fn get_profile_pic(
 	let mut map = std::collections::HashMap::new();
 	map.insert("username", username.clone());
     map.insert("token", token.clone());
-	let res = post_to_text("https://api.onlinedi.vision/api/get_user_pfp", map, "Failed to get PFP.")
+	let res = post_to_text("https://api.onlinedi.vision/get_user_pfp", map, "Failed to get PFP.")
 		.await
 		.expect("err");
     prelude::debug_only_print(&res);
@@ -55,7 +55,7 @@ pub(crate) async fn set_profile_pic(
 	map.insert("username", username.clone());
     map.insert("token", token.clone());
 	map.insert("img_url", img_url.clone());
-	let res = post_to_text("https://api.onlinedi.vision/api/set_user_pfp", map, "Failed to set profile pic.")
+	let res = post_to_text("https://api.onlinedi.vision/set_user_pfp", map, "Failed to set profile pic.")
 		.await
 		.expect("err");
     prelude::debug_only_print(&res);


### PR DESCRIPTION
Should be merged at the same time as https://github.com/onlinedi-vision/od-official-server/pull/57 takes effect. Removes `/api` from server API endpoints. Also I may have accidentally pushed to main at first because my hands were on autopilot, sorry about that.