### PR TITLE
core: ash is no longer accesible at the previous endpoint

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -147,12 +147,12 @@ export default {
 
         fileData.append("file", file);
 
-        fetch("https://onlinedi.vision:7377/upload", {
+        fetch("https://onlinedi.vision/ash/upload", {
           method: 'POST',
           body: fileData
         }).then(response => {
           response.text().then(mess => {
-            const to_append = "https://onlinedi.vision:7377" + mess.split(/\r?\n/).pop();
+            const to_append = "https://onlinedi.vision" + mess.split(/\r?\n/).pop();
             message += to_append;
 
             if (this.serverID === '1') { message = ''; this.message; }


### PR DESCRIPTION
This change should make the ash tray accesible again.