### PR TITLE
Organize main view into flex containers

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,44 @@
 <template >
   <main class="container" v-if="done && loggedin">
-
-    <form enctype='multipart/form-data' id="file-form" class="row" @submit.prevent="greet">
+	<div class="container-v">
+	  <img @click="openSettings()" v-bind:src='myPfp' width='60px' height='60px' class='cui'
+      style='margin-bottom:0px;' />
+	  
+	  <ServerList
+      :userServers="userServers"
+      :appState="appState"
+      :serverID="serverID"
+      :textChannel="textChannel"
+      @changeServer="change_server"
+      /> 
+	  
+	  <button class="createSButton" @click="createServer()">
+        <h2 style="margin-top: 12px">+</h2>
+      </button>
+	</div>
+	<ChannelList
+	:appState="appState"
+	:serverID="serverID"
+	:textChannel="textChannel"
+	:done="done"
+	:userServers="userServers"
+	@showSID="showSID"
+	@changeChannel="change_channel"
+	@createChannel="create_channel"
+	@deleteChannel="deleteChannel"
+	/>
+	<div class="container-v" style="flex-shrink: 1; min-width: 0;">
+	  <div id="channel-header">
+        <h3>{{this.textChannel}}</h3>
+      </div>
+	  <ChatWindow
+        :appState="appState"
+        :serverID="serverID"
+        :textChannel="textChannel"
+        :get_date="get_date"
+      />
+	<div>
+	<form enctype='multipart/form-data' id="file-form" class="row" @submit.prevent="greet">
       <input id="file-upload" type="file" @change="onFileChange" />
       <div v-if="selectedFileUrl" class="file-preview">
         <div style="font-size:12px;color:#aaa;">
@@ -26,38 +63,17 @@
       />
       <button id="send" type="submit" @click="send_message(message)">Send</button>
     </form>
-
-    
-    <img @click="openSettings()" v-bind:src='myPfp' width='60px' height='60px' class='cui'
-      style='margin-bottom:0px;' />
-    <button class="createSButton" @click="createServer()">
-      <h2 style="margin-top: 12px">+</h2>
-    </button>
-
-
-    <ServerList
-      :userServers="userServers"
+	</div>
+	</div>
+    <div>
+	  <ServerUsersList
       :appState="appState"
       :serverID="serverID"
-      :textChannel="textChannel"
-      @changeServer="change_server"
-    />  
-    
+      />
+	</div>
     <div v-if="showSIDvar" class="login" style="display:flex;flex-direction:row; left:100px; top:50px; height:30px; width:660px; z-index:999999;">
       <i style="font-size: 12px"> {{serverID}} </i>
     </div>
-
-      <ChannelList
-      :appState="appState"
-      :serverID="serverID"
-      :textChannel="textChannel"
-      :done="done"
-      :userServers="userServers"
-      @showSID="showSID"
-      @changeChannel="change_channel"
-      @createChannel="create_channel"
-	  @deleteChannel="deleteChannel"
-      />
 
       <div v-if="createChannelPopUp" class="login" style="display:flex;flex-direction:row; left:200px; top:100px; height:50px; width:280px">
         <input id="greet-input" v-model="nchn" style="width:200px" placeholder="new_channel_name..."/>
@@ -78,22 +94,6 @@
         <button class="csvb" @click="joinServer()">Join Server</button>
         <button class="csvb" @click="createServerCancel()">Cancel</button>
       </div>
-
-      <ChatWindow
-        :appState="appState"
-        :serverID="serverID"
-        :textChannel="textChannel"
-        :get_date="get_date"
-      />
-
-      <div id="channel-header">
-        <h3>{{this.textChannel}}</h3>
-      </div>
-
-      <ServerUsersList
-      :appState="appState"
-      :serverID="serverID"
-      />
 
   </main>
     <main v-else-if="!loggedin">

--- a/src/app.js
+++ b/src/app.js
@@ -152,7 +152,7 @@ export default {
           body: fileData
         }).then(response => {
           response.text().then(mess => {
-            const to_append = "https://onlinedi.vision" + mess.split(/\r?\n/).pop();
+            const to_append = "https://onlinedi.vision/" + mess.split(/\r?\n/).pop();
             message += to_append;
 
             if (this.serverID === '1') { message = ''; this.message; }

--- a/src/components/channelList.vue
+++ b/src/components/channelList.vue
@@ -111,6 +111,7 @@ export default {
 <style>
 .chanels {
   display: flex;
+  flex-shrink: 0;
   flex-direction: column;
 }
 .server-header {

--- a/src/components/serverList.vue
+++ b/src/components/serverList.vue
@@ -37,11 +37,8 @@ export default {
 .server_list {
   transition: 0.2s; 
   background-color: var(--dark-foreground-element-color);
-  position: absolute;
-  top: 75px;
-  left: 5px;
-  height: calc(100vh - 155px);
   width: 60px;
+  flex-grow: 1;
   z-index: 9999;
   border-radius: 40px 40px 40px 40px;
   border: 2px solid transparent;

--- a/src/components/serverUsersList.vue
+++ b/src/components/serverUsersList.vue
@@ -30,11 +30,11 @@ export default {
 
 <style scoped>
 .server-users {
+  flex-grow: 1;
   overflow-y: hidden;
   overflow-x: scroll;
   transition: 0.2s;
   background-color: var(--dark-foreground-element-color);
-  position: absolute;
   top: 5px;
   right: 5px;
   height: calc(100vh - 11px);

--- a/src/style.css
+++ b/src/style.css
@@ -59,12 +59,20 @@ input[type="file"] {
   background-color:var(--main-font-color);
 }
 .container {
-  margin: 0;
   height: 100%;
-  /*padding-top: 10vh;*/
-  /*display: flex;
-  --flex-direction: column;*/
-  justify-content: center;
+  width: 100vw;
+  display: flex;
+  flex-direction: row;
+  justify-content: left;
+  text-align: center;
+}
+
+.container-v{
+  margin: 4px 4px 4px 4px;
+  gap: 3px;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
   text-align: center;
 }
 
@@ -128,7 +136,6 @@ height: 40px; text-align:center; background-color:var(--dark-foreground-element-
 }
 
 .cui {
-  position: absolute;
   top: 5px;
   left: 5px;
   border-radius: 40px 40px 40px 40px;
@@ -139,10 +146,6 @@ transition: 0.2s;
 .row {
   display: flex;
   justify-content: center;
-  position: absolute;
-  bottom: 5px;
-  right: 0.5vw;
-  left: 300px;
   width: calc(100vw - 377px);
   z-index: 9999;
 }
@@ -167,8 +170,6 @@ transition: 0.2s;
 .createSButton {
     transition: 0.2s; 
     background-color: var(--dark-foreground-element-color);
-    position: absolute;
-    top:calc(100vh - 70px);
     left: 5px;
     height: 60px;
     width: 60px;
@@ -212,7 +213,6 @@ transition: 0.2s;
     overflow-x: scroll;
     transition: 0.2s;
     background-color: var(--dark-foreground-element-color);
-    position: absolute;
     top: 5px;
     right: 5px;
     height: calc(100vh - 11px);
@@ -223,12 +223,8 @@ transition: 0.2s;
   }
 
   .chanels {
-
     background-color: var(--normal-foreground-element-color);
-    position: absolute;
-    top: 5px;
-    left: 73px;
-    height: calc(100vh - 15px);
+    margin: 5px 0 5px 0;
     width: 220px;
     border: 2px  solid transparent;
     display: flex;
@@ -265,25 +261,23 @@ transition: 0.2s;
 #chat {
   display: flex;
   flex-direction: column-reverse;
-  position: absolute;
-  left: 300px;
-  width: calc(100vw - 372px);
-  top: 68px;
-  height: calc(100vh - 120px);
+  width: 100%;
+  min-width: 300px;
   overflow-y: scroll;
+  flex-grow: 1;
 }
 
 #chat .message img{
   max-width:480px;
   border-radius: 8px;
-  width: auto;
+  width: 100%;
   height: auto;
 }
 
 #chat .message video{
   max-width:480px;
   border-radius: 8px;
-  width: auto;
+  width: 100%;
   height: auto;
 }
 
@@ -301,7 +295,6 @@ transition: 0.2s;
 #channel-header {
   justify-content: center;
   text-align: left;
-  position: absolute;
   top: 5px;
   border-bottom: 2px solid var(--dark-foreground-element-color);
   width: calc(100vw - 380px);

--- a/src/style.css
+++ b/src/style.css
@@ -146,7 +146,6 @@ transition: 0.2s;
 .row {
   display: flex;
   justify-content: center;
-  width: calc(100vw - 377px);
   z-index: 9999;
 }
 
@@ -284,7 +283,7 @@ transition: 0.2s;
 .file-preview{
   position:absolute; 
   z-index:10000; 
-  left: 12px; 
+  left: 300px; 
   bottom: 56px; 
   max-width: 320px; 
   background:var(--normal-foreground-element-color); 


### PR DESCRIPTION
In this PR, I organized the components of the app's main view (server list, channels, chat, user list) into flex containers in order to make the interface easier to modify and prepare it for dynamically hiding elements on mobile screens. Most important changes are in `App.vue` (reorganized all elements and arranged into divs inside the main container) and `style.css` (applied flex properties to elements).